### PR TITLE
fix return value for RData

### DIFF
--- a/lib/Rdata/A.php
+++ b/lib/Rdata/A.php
@@ -33,7 +33,7 @@ class A implements RdataInterface
     /**
      * @return string
      */
-    public function getAddress(): string
+    public function getAddress(): ?string
     {
         return $this->address;
     }

--- a/lib/Rdata/CNAME.php
+++ b/lib/Rdata/CNAME.php
@@ -33,7 +33,7 @@ class CNAME implements RdataInterface
     /**
      * @return string
      */
-    public function getTarget(): string
+    public function getTarget(): ?string
     {
         return $this->target;
     }

--- a/lib/Rdata/HINFO.php
+++ b/lib/Rdata/HINFO.php
@@ -38,7 +38,7 @@ class HINFO implements RdataInterface
     /**
      * @return string
      */
-    public function getCpu(): string
+    public function getCpu(): ?string
     {
         return $this->cpu;
     }
@@ -54,7 +54,7 @@ class HINFO implements RdataInterface
     /**
      * @return string
      */
-    public function getOs(): string
+    public function getOs(): ?string
     {
         return $this->os;
     }

--- a/lib/Rdata/LOC.php
+++ b/lib/Rdata/LOC.php
@@ -74,7 +74,7 @@ class LOC implements RdataInterface
     /**
      * @param string $format
      *
-     * @return float|string
+     * @return float|string|null
      */
     public function getLatitude(string $format = self::FORMAT_DECIMAL)
     {
@@ -96,7 +96,7 @@ class LOC implements RdataInterface
     /**
      * @param string $format
      *
-     * @return float|string
+     * @return float|string|null
      */
     public function getLongitude(string $format = self::FORMAT_DECIMAL)
     {

--- a/lib/Rdata/MX.php
+++ b/lib/Rdata/MX.php
@@ -38,7 +38,7 @@ class MX implements RdataInterface
     /**
      * @return string
      */
-    public function getExchange(): string
+    public function getExchange(): ?string
     {
         return $this->exchange;
     }
@@ -54,7 +54,7 @@ class MX implements RdataInterface
     /**
      * @return int
      */
-    public function getPreference(): int
+    public function getPreference(): ?int
     {
         return $this->preference;
     }

--- a/lib/Rdata/SOA.php
+++ b/lib/Rdata/SOA.php
@@ -88,7 +88,7 @@ class SOA implements RdataInterface
     /**
      * @return int
      */
-    public function getExpire(): int
+    public function getExpire(): ?int
     {
         return $this->expire;
     }
@@ -104,7 +104,7 @@ class SOA implements RdataInterface
     /**
      * @return int
      */
-    public function getMinimum(): int
+    public function getMinimum(): ?int
     {
         return $this->minimum;
     }
@@ -120,7 +120,7 @@ class SOA implements RdataInterface
     /**
      * @return string
      */
-    public function getMname(): string
+    public function getMname(): ?string
     {
         return $this->mname;
     }
@@ -136,7 +136,7 @@ class SOA implements RdataInterface
     /**
      * @return int
      */
-    public function getRefresh(): int
+    public function getRefresh(): ?int
     {
         return $this->refresh;
     }
@@ -152,7 +152,7 @@ class SOA implements RdataInterface
     /**
      * @return int
      */
-    public function getRetry(): int
+    public function getRetry(): ?int
     {
         return $this->retry;
     }
@@ -168,7 +168,7 @@ class SOA implements RdataInterface
     /**
      * @return string
      */
-    public function getRname(): string
+    public function getRname(): ?string
     {
         return $this->rname;
     }
@@ -184,7 +184,7 @@ class SOA implements RdataInterface
     /**
      * @return int
      */
-    public function getSerial(): int
+    public function getSerial(): ?int
     {
         return $this->serial;
     }

--- a/lib/Rdata/SRV.php
+++ b/lib/Rdata/SRV.php
@@ -61,7 +61,7 @@ class SRV extends CNAME
     /**
      * @return int
      */
-    public function getPriority(): int
+    public function getPriority(): ?int
     {
         return $this->priority;
     }
@@ -83,7 +83,7 @@ class SRV extends CNAME
     /**
      * @return int
      */
-    public function getWeight(): int
+    public function getWeight(): ?int
     {
         return $this->weight;
     }
@@ -105,7 +105,7 @@ class SRV extends CNAME
     /**
      * @return int
      */
-    public function getPort(): int
+    public function getPort(): ?int
     {
         return $this->port;
     }

--- a/lib/Rdata/TXT.php
+++ b/lib/Rdata/TXT.php
@@ -30,7 +30,7 @@ class TXT implements RdataInterface
         $this->text = addslashes($text);
     }
 
-    public function getText(): string
+    public function getText(): ?string
     {
         return stripslashes($this->text);
     }

--- a/lib/Zone.php
+++ b/lib/Zone.php
@@ -61,7 +61,7 @@ class Zone implements \Countable, \IteratorAggregate
     /**
      * @return string
      */
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }


### PR DESCRIPTION
When an rdata is created with the method `Factory::newRdataFromName`, all the attributes are `null`