### PR TITLE
Fix Rdata Caa target record: do not double quotes using DNS-parser record import feature

### DIFF
--- a/lib/Rdata/CAA.php
+++ b/lib/Rdata/CAA.php
@@ -98,7 +98,7 @@ class CAA extends CNAME
         return sprintf('%s %s "%s"',
             $this->flag,
             $this->tag,
-            $this->target
+            preg_replace('/"|\'/', '', $this->target)
         );
     }
 }


### PR DESCRIPTION
Fix Rdata Caa target record: do not double quotes using DNS-parser record import feature
