### PR TITLE
add record validation against `CNAME` records

### DIFF
--- a/lib/Validator.php
+++ b/lib/Validator.php
@@ -11,6 +11,7 @@
 
 namespace Badcow\DNS;
 
+use Badcow\DNS\Rdata\CNAME;
 use Badcow\DNS\Rdata\NS;
 use Badcow\DNS\Rdata\SOA;
 
@@ -239,5 +240,27 @@ class Validator
         }
 
         return count($classes);
+    }
+
+    /**
+     * Check if the record could be inserted in the zone by checking the CNAME aliases.
+     *
+     * @see https://tools.ietf.org/html/rfc1034#section-3.6.2
+     *
+     * @param Zone           $zone
+     * @param ResourceRecord $newRecord
+     *
+     * @return bool
+     */
+    public static function record(Zone $zone, ResourceRecord $newRecord): bool
+    {
+        foreach ($zone as $rr) {
+            if (CNAME::TYPE === $rr->getType()
+                && $newRecord->getName() === $rr->getName()) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -352,4 +352,25 @@ class ValidatorTest extends TestCase
     {
         $this->assertTrue(Validator::hostName('ya-hoo123'));
     }
+
+    public function testRecordInsertion()
+    {
+        //Pass case
+        $txt1 = new ResourceRecord();
+        $txt1->setName('www');
+        $txt1->setRdata(Factory::txt('v=spf1 ip4:192.0.2.0/24 ip4:198.51.100.123 a -all'));
+        $txt1->setClass(Classes::INTERNET);
+
+        //Fail case
+        $txt2 = new ResourceRecord();
+        $txt2->setName('alias');
+        $txt2->setRdata(Factory::txt('v=spf1 ip4:192.0.2.0/24 ip4:198.51.100.123 a -all'));
+        $txt2->setClass(Classes::INTERNET);
+
+        $zone = $this->buildTestZone();
+
+        $this->assertTrue(Validator::record($zone, $txt1));
+
+        $this->assertFalse(Validator::record($zone, $txt2));
+    }
 }


### PR DESCRIPTION
Once a `CNAME` record is inserted, no other record could have the same name