### PR TITLE
ttl ressource record could be set to null

### DIFF
--- a/lib/ResourceRecord.php
+++ b/lib/ResourceRecord.php
@@ -106,7 +106,7 @@ class ResourceRecord
      *
      * @param int $ttl
      */
-    public function setTtl(int $ttl): void
+    public function setTtl(?int $ttl): void
     {
         $this->ttl = $ttl;
     }


### PR DESCRIPTION
Allow to set to null the `ttl` of an instanced `RessourceRecord`. 

By default the `ttl` of a `RessourceRecord` is null, but once it was set, it was impossible to make it null again.