### PR TITLE
MX::output() throws exception on missing parameters.

### DIFF
--- a/lib/Rdata/MX.php
+++ b/lib/Rdata/MX.php
@@ -64,9 +64,19 @@ class MX implements RdataInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \InvalidArgumentException Throws exception if preference or exchange have not been set.
      */
     public function output(): string
     {
+        if (null === $this->preference) {
+            throw new \InvalidArgumentException('No preference has been set on MX object.');
+        }
+
+        if (null === $this->exchange) {
+            throw new \InvalidArgumentException('No exchange has been set on MX object.');
+        }
+
         return $this->preference.' '.$this->exchange;
     }
 }

--- a/tests/Rdata/MxRdataTest.php
+++ b/tests/Rdata/MxRdataTest.php
@@ -12,6 +12,7 @@
 namespace Badcow\DNS\Tests\Rdata;
 
 use Badcow\DNS\Rdata\MX;
+use Badcow\DNS\ResourceRecord;
 
 class MxRdataTest extends \PHPUnit\Framework\TestCase
 {
@@ -35,5 +36,25 @@ class MxRdataTest extends \PHPUnit\Framework\TestCase
         $mx->setPreference(42);
 
         $this->assertEquals('42 foo.example.com.', $mx->output());
+    }
+
+    public function testOutputThrowsExceptionWhenMissingPreference()
+    {
+        $mx = new MX();
+        $mx->setExchange('mail.google.com.');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No preference has been set on MX object.');
+        $mx->output();
+    }
+
+    public function testOutputThrowsExceptionWhenMissingExchange()
+    {
+        $mx = new MX();
+        $mx->setPreference(15);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No exchange has been set on MX object.');
+        $mx->output();
     }
 }


### PR DESCRIPTION
Issue #33 