### PR TITLE
Resolves issue #72

### DIFF
--- a/lib/Parser/Normaliser.php
+++ b/lib/Parser/Normaliser.php
@@ -197,7 +197,7 @@ class Normaliser
         $lines = [];
 
         foreach (explode(Tokens::LINE_FEED, $string) as $line) {
-            if ('' !== $line = trim($line)) {
+            if ('' !== $line = rtrim($line)) {
                 $lines[] = $line;
             }
         }

--- a/lib/Parser/Parser.php
+++ b/lib/Parser/Parser.php
@@ -306,7 +306,7 @@ class Parser
     }
 
     /**
-     * Determine if the iterant is a TTL (i.e. it is an integer).
+     * Determine if the iterant is a TTL (i.e. it is an integer after domain-name).
      *
      * @param ResourceRecordIterator $iterator
      * @param string                 $origin   the previously assumed resource record parameter, either 'CLASS' or NULL
@@ -319,6 +319,10 @@ class Parser
             return false;
         }
 
+        if ($iterator->key() <= 1) {
+            return false;
+        }
+        
         $iterator->next();
         if ('CLASS' === $origin) {
             $isTtl = $this->isType($iterator);

--- a/lib/Parser/Parser.php
+++ b/lib/Parser/Parser.php
@@ -118,7 +118,6 @@ class Parser
         list($entry, $comment) = $this->extractComment($line);
 
         $this->currentResourceRecord = new ResourceRecord();
-        $this->currentResourceRecord->setTtl($this->zone->getDefaultTtl());
         $this->currentResourceRecord->setComment($comment);
 
         if ('' === $entry) {
@@ -194,7 +193,7 @@ class Parser
         }
 
         if (null === $this->currentResourceRecord->getTtl()) {
-            $this->currentResourceRecord->setTtl($this->lastStatedTtl);
+            $this->currentResourceRecord->setTtl($this->lastStatedTtl ?? $this->zone->getDefaultTTl());
         } else {
             $this->lastStatedTtl = $this->currentResourceRecord->getTtl();
         }

--- a/lib/Parser/Parser.php
+++ b/lib/Parser/Parser.php
@@ -319,7 +319,7 @@ class Parser
             return false;
         }
 
-        if ($iterator->key() <= 1) {
+        if ($iterator->key() < 1) {
             return false;
         }
         

--- a/lib/Parser/Parser.php
+++ b/lib/Parser/Parser.php
@@ -187,7 +187,7 @@ class Parser
      */
     private function populateWithLastStated(): void
     {
-        if (null === $this->currentResourceRecord->getName()) {
+        if (empty($this->currentResourceRecord->getName())) {
             $this->currentResourceRecord->setName($this->lastStatedDomain);
         } else {
             $this->lastStatedDomain = $this->currentResourceRecord->getName();

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -259,7 +259,7 @@ TXT;
      */
     public function testParserCanHandleUriRecords(): void
     {
-        $txt = '   _ftp._tcp    IN URI 10 1 "ftp://ftp1.example.com/public%20data"';
+        $txt = '_ftp._tcp    IN URI 10 1 "ftp://ftp1.example.com/public%20data"';
         $zone = Parser::parse('example.com.', $txt);
 
         $rrs = self::findRecord('_ftp._tcp', $zone, 'URI');

--- a/tests/Parser/Resources/ambiguous.acme.org.txt
+++ b/tests/Parser/Resources/ambiguous.acme.org.txt
@@ -2,8 +2,8 @@ $ORIGIN ambiguous.acme.org.
 
 ambiguous.acme.org. IN SOA ambiguous.acme.org. post.acme.org. 2019092401 3600 14400 604800 1800
 
-mx 900 IN A 200.100.50.35
-aaaa IN AAAA 2001:acdc:5889::35
-3600 TXT "This name is silly."
-mx cname aaaa
-IN TXT "Mail Exchange IPv6 Address"
+ mx 900 IN A 200.100.50.35
+ aaaa IN AAAA 2001:acdc:5889::35
+ 3600 TXT "This name is silly."
+ mx cname aaaa
+ IN TXT "Mail Exchange IPv6 Address"

--- a/tests/Parser/Resources/ambiguous.acme.org.txt
+++ b/tests/Parser/Resources/ambiguous.acme.org.txt
@@ -2,8 +2,8 @@ $ORIGIN ambiguous.acme.org.
 
 ambiguous.acme.org. IN SOA ambiguous.acme.org. post.acme.org. 2019092401 3600 14400 604800 1800
 
- mx 900 IN A 200.100.50.35
- aaaa IN AAAA 2001:acdc:5889::35
+mx 900 IN A 200.100.50.35
+aaaa IN AAAA 2001:acdc:5889::35
  3600 TXT "This name is silly."
- mx cname aaaa
+mx cname aaaa
  IN TXT "Mail Exchange IPv6 Address"

--- a/tests/Parser/Resources/testConvolutedZone_sample.txt
+++ b/tests/Parser/Resources/testConvolutedZone_sample.txt
@@ -18,9 +18,9 @@ test 600 IN TXT (;11111
 testtxt 600 IN TXT ("v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDZKI3U+9acu3NfEy0NJHIPydxnPLPpnAJ7"
 "k2JdrsLqAK1uouMudHI20pgE8RMldB/TeWKXYoRidcGCZWXleUzldDTwZAMDQNpdH1uuxym0VhoZpPbI1RXwpgHRTbCk49VqlC")
 testmx 600    IN MX 20 @;345345
-300 IN MX 30 mail.com.
-IN MX 35 mail-gw3
-MX 40 mail-gw4
+ 300 IN MX 30 mail.com.
+ IN MX 35 mail-gw3
+ MX 40 mail-gw4
 testmx2 600 IN MX 20 .;23''33'123;;123;
 _domainkeytxt 600 IN TXT "t=y;o=~;\0";312
 www 600 IN TXT "@ A 79.125.10.157 "

--- a/tests/Parser/Resources/testMultilineTxtRecords_sample.txt
+++ b/tests/Parser/Resources/testMultilineTxtRecords_sample.txt
@@ -1,6 +1,6 @@
 
 
-    test	IN		7230           TXT "This is an "(
+test	IN		7230           TXT "This is an "(
 
 										"example of a "
 										"multiline TXT "


### PR DESCRIPTION
This PR will:
- prevent trimming whitespaces from the beginning of lines
- prevent considering first element of an entry as TTL
- consider both null and empty domain-name as not stated

Closes #72 