### PR TITLE
TXT quote escapes

### DIFF
--- a/lib/AlignedRdataFormatters.php
+++ b/lib/AlignedRdataFormatters.php
@@ -93,8 +93,11 @@ class AlignedRdataFormatters
 
         $rdata = Tokens::OPEN_BRACKET.Tokens::SPACE;
         foreach ($lines as $line) {
-            $rdata .= Tokens::LINE_FEED.$padString.Tokens::SPACE.Tokens::SPACE.
-                Tokens::DOUBLE_QUOTES.$line.Tokens::DOUBLE_QUOTES;
+
+            $txtSplit = new TXT();
+            $txtSplit->setText($line);
+
+            $rdata .= Tokens::LINE_FEED.$padString.Tokens::SPACE.Tokens::SPACE.$txtSplit->toText();
         }
         $rdata .= Tokens::LINE_FEED.$padString.Tokens::CLOSE_BRACKET;
 

--- a/lib/Rdata/TXT.php
+++ b/lib/Rdata/TXT.php
@@ -52,7 +52,10 @@ class TXT implements RdataInterface
      */
     public function toText(): string
     {
-        return sprintf('"%s"', addslashes($this->text ?? ''));
+        return sprintf(
+            Tokens::DOUBLE_QUOTES . '%s' . Tokens::DOUBLE_QUOTES, 
+            addcslashes($this->text ?? '', Tokens::DOUBLE_QUOTES . '\\')
+        );
     }
 
     /**

--- a/tests/Rdata/TxtTest.php
+++ b/tests/Rdata/TxtTest.php
@@ -29,12 +29,11 @@ class TxtTest extends TestCase
 
     public function testOutput(): void
     {
-        $text = 'This is some text. It\'s a nice piece of text.';
-        $expected = '"This is some text. It\\\'s a nice piece of text."';
+        $text = '"This is some quoted text". It\'s a nice piece of text.';
+        $expected = '"\"This is some quoted text\". It\'s a nice piece of text."';
         $txt = new TXT();
         $txt->setText($text);
 
-        $this->assertEquals($expected, $txt->toText());
         $this->assertEquals($expected, $txt->toText());
     }
 


### PR DESCRIPTION
Hi,

1) addslashes in `TXT::toText()` replaced by addcslashes to limit the escapes to "double quotes" tokens. Other tokens like ' should not be escaped.

2) If TXT::text is splitted by `AlignedRdataFormatters::TXT`, the chunks (lines) should also be escaped.