### PR TITLE
AlignedRdataFormatters::TXT - rise text length to maximum

### DIFF
--- a/lib/AlignedRdataFormatters.php
+++ b/lib/AlignedRdataFormatters.php
@@ -80,15 +80,15 @@ class AlignedRdataFormatters
     }
 
     /**
-     * Split the TXT string into 40 character lines if the string is larger than 50 characters.
+     * Split the TXT string into 255 character lines if the string is larger than 255 characters.
      */
     public static function TXT(TXT $txt, int $padding): string
     {
-        if (null === $txt->getText() || strlen($txt->getText()) <= 50) {
+        if (null === $txt->getText() || strlen($txt->getText()) <= 255) {
             return $txt->toText();
         }
 
-        $lines = str_split($txt->getText(), 40);
+        $lines = str_split($txt->getText(), 255);
         $padString = str_repeat(Tokens::SPACE, $padding);
 
         $rdata = Tokens::OPEN_BRACKET.Tokens::SPACE;


### PR DESCRIPTION
Hi,

i have the problem, that Google Search Console does not accept a splitted  DNS TXT authentication string.

But there are very long TXT strings (dkim keys) where it is necessary to split them.
So i can't use the Zonebuilder, because that will not split the TXT string.

We found no reference for the used limit of 50 or 40 characters.
But there is a limit per TXT string of 255 characters:
https://kb.isc.org/docs/aa-00356

So i suggest to rise the TXT string length to maximum.