### PR TITLE
Do not add double dot when $ORIGIN is `.'

### DIFF
--- a/lib/Parser/Parser.php
+++ b/lib/Parser/Parser.php
@@ -233,6 +233,10 @@ class Parser
             return $subdomain;
         }
 
+        if ($this->origin === '.') {
+            return $subdomain.'.';
+        }
+
         if ('@' === $subdomain) {
             return $this->origin;
         }

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -531,6 +531,23 @@ DNS;
         $this->assertEquals($expectation, ZoneBuilder::build($zone));
     }
 
+    /**
+     * Parser handles $ORIGIN . correctly.
+     *
+     * @throws ParseException|\Exception
+     */
+    public function testParserHandlesOriginDot(): void
+    {
+        $file = NormaliserTest::readFile(__DIR__.'/Resources/testOriginDot_sample.txt');
+        $expectation = NormaliserTest::readfile(__DIR__.'/Resources/testOriginDot_expectation.txt');
+
+        $zone = Parser::parse('otherdomain.biz.', $file);
+        $this->assertEquals('otherdomain.biz.', $zone->getName());
+
+        ZoneBuilder::fillOutZone($zone);
+        $this->assertEquals($expectation, ZoneBuilder::build($zone));
+    }
+
     public function dp_testParserHandlesIncludeDirective(): array
     {
         $baseDir = __DIR__.'/Resources/IncludeControlEntryTests/';

--- a/tests/Parser/Resources/testOriginDot_expectation.txt
+++ b/tests/Parser/Resources/testOriginDot_expectation.txt
@@ -1,0 +1,10 @@
+$ORIGIN otherdomain.biz.
+$TTL 3600
+otherdomain.biz. 3600 IN SOA otherdomain.biz. post.otherdomain.biz. 2014110501 3600 14400 604800 3600
+otherdomain.biz. 3600 IN NS ns1.nameserver.com.
+otherdomain.biz. 3600 IN NS ns2.nameserver.com.
+info.otherdomain.biz. 3600 IN TXT "This is some additional \"information\""
+sub.domain.otherdomain.biz. 3600 IN A 192.168.1.42
+ipv6.domain.otherdomain.biz. 3600 IN AAAA 0000:0000:0000:0000:0000:0000:0000:0001
+mail.otherdomain.biz. 3600 IN CNAME mx1.bizmail.
+otherdomain.biz. 3600 IN MX 10 mail.otherdomain.biz.

--- a/tests/Parser/Resources/testOriginDot_sample.txt
+++ b/tests/Parser/Resources/testOriginDot_sample.txt
@@ -1,0 +1,14 @@
+$ORIGIN .
+$TTL 3600
+
+otherdomain.biz IN SOA otherdomain.biz. post.otherdomain.biz. 2014110501 3600 14400 604800 3600
+
+otherdomain.biz NS ns1.nameserver.com.
+otherdomain.biz NS ns2.nameserver.com.
+
+info.otherdomain.biz TXT "This is some additional \"information\""
+sub.domain.otherdomain.biz A 192.168.1.42
+ipv6.domain.otherdomain.biz AAAA ::1
+
+mail.otherdomain.biz IN CNAME mx1.bizmail.
+otherdomain.biz IN MX 10 mail


### PR DESCRIPTION
A zone file containing `$ORIGIN .` would cause an extra `.' being added
on host names in that zone after parsing.

PowerDNS' `pdnsutil` tool produces such zone files by default.