### PR TITLE
Support for RR canonical form (RFC4034)

### DIFF
--- a/lib/Message.php
+++ b/lib/Message.php
@@ -121,11 +121,28 @@ class Message
 
     /**
      * Encode a domain name as a sequence of labels.
+     *
+     * @param string $name  Name to encode
+     * @param string $origin If specified and $name is relative, then append to $name
+     * @param bool $canonicalize  Convert $name to canonicalized format,
+     *                              that is all characters lowercase, fully qualified and no compression.
      */
-    public static function encodeName(string $name): string
+    public static function encodeName(string $name, string $origin = null, bool $canonicalize = false): string
     {
         if ('.' === $name) {
             return chr(0);
+        }
+
+        if (null !== $origin && '.' !== $name[-1]) {
+            $name .= $origin;
+        }
+
+        if ($canonicalize) {
+            if (!Validator::fullyQualifiedDomainName($name)) {
+                throw new \InvalidArgumentException(sprintf('Name "%s" is not a fully qualified domain name but canonicalized name was requested.', $name));
+            }
+
+            $name = strtolower($name);
         }
 
         $name = rtrim($name, '.').'.';

--- a/lib/Message.php
+++ b/lib/Message.php
@@ -133,13 +133,17 @@ class Message
             return chr(0);
         }
 
-        if (null !== $origin && '.' !== $name[-1]) {
-            $name .= $origin;
+        if (null !== $origin) {
+            if ('@' === $name) {
+                $name = $origin;
+            } elseif ('.' !== $name[-1]) {
+                $name .= '.' . $origin;
+            }
         }
 
         if ($canonicalize) {
-            if (!Validator::fullyQualifiedDomainName($name)) {
-                throw new \InvalidArgumentException(sprintf('Name "%s" is not a fully qualified domain name but canonicalized name was requested.', $name));
+            if ('.' !== $name[-1]) {
+                throw new \InvalidArgumentException(sprintf('Name "%s" is not a absolute domain name while canonicalized name format was requested.', $name));
             }
 
             $name = strtolower($name);

--- a/lib/Rdata/A.php
+++ b/lib/Rdata/A.php
@@ -55,7 +55,7 @@ class A implements RdataInterface
     /**
      * @throws \InvalidArgumentException
      */
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         if (false === $encoded = @inet_pton($this->address)) {
             throw new \InvalidArgumentException(sprintf('The IP address "%s" cannot be encoded. Check that it is a valid IP address.', $this->address));

--- a/lib/Rdata/A.php
+++ b/lib/Rdata/A.php
@@ -55,7 +55,7 @@ class A implements RdataInterface
     /**
      * @throws \InvalidArgumentException
      */
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         if (false === $encoded = @inet_pton($this->address)) {
             throw new \InvalidArgumentException(sprintf('The IP address "%s" cannot be encoded. Check that it is a valid IP address.', $this->address));

--- a/lib/Rdata/AFSDB.php
+++ b/lib/Rdata/AFSDB.php
@@ -68,9 +68,9 @@ class AFSDB implements RdataInterface
         return sprintf('%d %s', $this->subType, $this->hostname);
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
-        return pack('n', $this->subType).Message::encodeName($this->hostname);
+        return pack('n', $this->subType).Message::encodeName($this->hostname, $origin, $canonicalize);
     }
 
     public function fromText(string $text): void

--- a/lib/Rdata/AFSDB.php
+++ b/lib/Rdata/AFSDB.php
@@ -68,7 +68,7 @@ class AFSDB implements RdataInterface
         return sprintf('%d %s', $this->subType, $this->hostname);
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return pack('n', $this->subType).Message::encodeName($this->hostname, $origin, $canonicalize);
     }

--- a/lib/Rdata/APL.php
+++ b/lib/Rdata/APL.php
@@ -82,7 +82,7 @@ class APL implements RdataInterface
         return rtrim($string, ' ');
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         $encoded = '';
 

--- a/lib/Rdata/APL.php
+++ b/lib/Rdata/APL.php
@@ -82,7 +82,7 @@ class APL implements RdataInterface
         return rtrim($string, ' ');
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         $encoded = '';
 

--- a/lib/Rdata/CAA.php
+++ b/lib/Rdata/CAA.php
@@ -124,7 +124,7 @@ class CAA implements RdataInterface
         );
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         if (!isset($this->tag) || !isset($this->flag) || !isset($this->value)) {
             throw new \InvalidArgumentException('All CAA parameters must be set.');

--- a/lib/Rdata/CAA.php
+++ b/lib/Rdata/CAA.php
@@ -124,7 +124,7 @@ class CAA implements RdataInterface
         );
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         if (!isset($this->tag) || !isset($this->flag) || !isset($this->value)) {
             throw new \InvalidArgumentException('All CAA parameters must be set.');

--- a/lib/Rdata/CERT.php
+++ b/lib/Rdata/CERT.php
@@ -149,7 +149,7 @@ class CERT implements RdataInterface
         return sprintf('%s %s %s %s', $type, (string) $this->keyTag, $algorithm, base64_encode($this->certificate));
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return pack('nnC', $this->certificateType, $this->keyTag, $this->algorithm).$this->certificate;
     }

--- a/lib/Rdata/CERT.php
+++ b/lib/Rdata/CERT.php
@@ -149,7 +149,7 @@ class CERT implements RdataInterface
         return sprintf('%s %s %s %s', $type, (string) $this->keyTag, $algorithm, base64_encode($this->certificate));
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         return pack('nnC', $this->certificateType, $this->keyTag, $this->algorithm).$this->certificate;
     }

--- a/lib/Rdata/CNAME.php
+++ b/lib/Rdata/CNAME.php
@@ -48,13 +48,13 @@ class CNAME implements RdataInterface
         return $this->target ?? '';
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         if (null === $this->target) {
             throw new \InvalidArgumentException('Target must be set.');
         }
 
-        return Message::encodeName($this->target);
+        return Message::encodeName($this->target, $origin, $canonicalize);
     }
 
     public function fromText(string $text): void

--- a/lib/Rdata/CNAME.php
+++ b/lib/Rdata/CNAME.php
@@ -48,7 +48,7 @@ class CNAME implements RdataInterface
         return $this->target ?? '';
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         if (null === $this->target) {
             throw new \InvalidArgumentException('Target must be set.');

--- a/lib/Rdata/CSYNC.php
+++ b/lib/Rdata/CSYNC.php
@@ -86,7 +86,7 @@ class CSYNC implements RdataInterface
     /**
      * @throws UnsupportedTypeException
      */
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         return pack('Nn', $this->soaSerial, $this->flags).NSEC::renderBitmap($this->types);
     }

--- a/lib/Rdata/CSYNC.php
+++ b/lib/Rdata/CSYNC.php
@@ -86,7 +86,7 @@ class CSYNC implements RdataInterface
     /**
      * @throws UnsupportedTypeException
      */
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return pack('Nn', $this->soaSerial, $this->flags).NSEC::renderBitmap($this->types);
     }

--- a/lib/Rdata/DHCID.php
+++ b/lib/Rdata/DHCID.php
@@ -184,7 +184,7 @@ class DHCID implements RdataInterface
         return base64_encode($this->toWire());
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         if (null === $this->digest) {
             $this->calculateDigest();

--- a/lib/Rdata/DHCID.php
+++ b/lib/Rdata/DHCID.php
@@ -184,7 +184,7 @@ class DHCID implements RdataInterface
         return base64_encode($this->toWire());
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         if (null === $this->digest) {
             $this->calculateDigest();

--- a/lib/Rdata/DS.php
+++ b/lib/Rdata/DS.php
@@ -122,7 +122,7 @@ class DS implements RdataInterface
         );
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return pack('nCC', $this->keyTag, $this->algorithm, $this->digestType).$this->digest;
     }

--- a/lib/Rdata/DS.php
+++ b/lib/Rdata/DS.php
@@ -122,7 +122,7 @@ class DS implements RdataInterface
         );
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         return pack('nCC', $this->keyTag, $this->algorithm, $this->digestType).$this->digest;
     }

--- a/lib/Rdata/HINFO.php
+++ b/lib/Rdata/HINFO.php
@@ -67,7 +67,7 @@ class HINFO implements RdataInterface
         return sprintf('"%s" "%s"', $this->cpu ?? '', $this->os ?? '');
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return $this->toText();
     }

--- a/lib/Rdata/HINFO.php
+++ b/lib/Rdata/HINFO.php
@@ -67,7 +67,7 @@ class HINFO implements RdataInterface
         return sprintf('"%s" "%s"', $this->cpu ?? '', $this->os ?? '');
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         return $this->toText();
     }

--- a/lib/Rdata/HIP.php
+++ b/lib/Rdata/HIP.php
@@ -113,7 +113,7 @@ class HIP implements RdataInterface
         );
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         $rdata = pack('CCn',
             strlen($this->hostIdentityTag),

--- a/lib/Rdata/HIP.php
+++ b/lib/Rdata/HIP.php
@@ -113,7 +113,7 @@ class HIP implements RdataInterface
         );
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         $rdata = pack('CCn',
             strlen($this->hostIdentityTag),
@@ -124,7 +124,7 @@ class HIP implements RdataInterface
         $rdata .= $this->hostIdentityTag;
         $rdata .= $this->publicKey;
         foreach ($this->rendezvousServers as $server) {
-            $rdata .= Message::encodeName($server);
+            $rdata .= Message::encodeName($server, $origin, $canonicalize);
         }
 
         return $rdata;

--- a/lib/Rdata/IPSECKEY.php
+++ b/lib/Rdata/IPSECKEY.php
@@ -206,7 +206,7 @@ class IPSECKEY implements RdataInterface
         ));
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         $wire = pack('CCC', $this->precedence, $this->gatewayType, $this->algorithm);
         if (1 === $this->gatewayType || 2 === $this->gatewayType) {
@@ -215,7 +215,7 @@ class IPSECKEY implements RdataInterface
             }
             $wire .= inet_pton($this->gateway);
         } else {
-            $wire .= Message::encodeName($this->gateway ?? '.');
+            $wire .= Message::encodeName($this->gateway ?? '.', $origin, $canonicalize);
         }
 
         if (self::ALGORITHM_NONE !== $this->algorithm && null !== $this->publicKey) {

--- a/lib/Rdata/IPSECKEY.php
+++ b/lib/Rdata/IPSECKEY.php
@@ -206,7 +206,7 @@ class IPSECKEY implements RdataInterface
         ));
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         $wire = pack('CCC', $this->precedence, $this->gatewayType, $this->algorithm);
         if (1 === $this->gatewayType || 2 === $this->gatewayType) {

--- a/lib/Rdata/KEY.php
+++ b/lib/Rdata/KEY.php
@@ -103,7 +103,7 @@ class KEY implements RdataInterface
         return sprintf('%d %d %d %s', $this->flags, $this->protocol, $this->algorithm, base64_encode($this->publicKey));
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return pack('nCC', $this->flags, $this->protocol, $this->algorithm).$this->publicKey;
     }

--- a/lib/Rdata/KEY.php
+++ b/lib/Rdata/KEY.php
@@ -103,7 +103,7 @@ class KEY implements RdataInterface
         return sprintf('%d %d %d %s', $this->flags, $this->protocol, $this->algorithm, base64_encode($this->publicKey));
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         return pack('nCC', $this->flags, $this->protocol, $this->algorithm).$this->publicKey;
     }

--- a/lib/Rdata/KX.php
+++ b/lib/Rdata/KX.php
@@ -70,7 +70,7 @@ class KX implements RdataInterface
         return $this->preference.' '.$this->exchanger;
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         if (null === $this->preference) {
             throw new \InvalidArgumentException('No preference has been set on KX object.');

--- a/lib/Rdata/KX.php
+++ b/lib/Rdata/KX.php
@@ -70,7 +70,7 @@ class KX implements RdataInterface
         return $this->preference.' '.$this->exchanger;
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         if (null === $this->preference) {
             throw new \InvalidArgumentException('No preference has been set on KX object.');
@@ -79,7 +79,7 @@ class KX implements RdataInterface
             throw new \InvalidArgumentException('No exchanger has been set on KX object.');
         }
 
-        return pack('n', $this->preference).Message::encodeName($this->exchanger);
+        return pack('n', $this->preference).Message::encodeName($this->exchanger, $origin, $canonicalize);
     }
 
     public function fromText(string $text): void

--- a/lib/Rdata/LOC.php
+++ b/lib/Rdata/LOC.php
@@ -196,7 +196,7 @@ class LOC implements RdataInterface
         return sprintf('%d %d %.3f %s', $d, $m, $s, $h);
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         return pack('CCCClll',
             0,

--- a/lib/Rdata/LOC.php
+++ b/lib/Rdata/LOC.php
@@ -196,7 +196,7 @@ class LOC implements RdataInterface
         return sprintf('%d %d %.3f %s', $d, $m, $s, $h);
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return pack('CCCClll',
             0,

--- a/lib/Rdata/MX.php
+++ b/lib/Rdata/MX.php
@@ -71,7 +71,7 @@ class MX implements RdataInterface
         return $this->preference.' '.$this->exchange;
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         if (null === $this->preference) {
             throw new \InvalidArgumentException('No preference has been set on MX object.');

--- a/lib/Rdata/MX.php
+++ b/lib/Rdata/MX.php
@@ -71,7 +71,7 @@ class MX implements RdataInterface
         return $this->preference.' '.$this->exchange;
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         if (null === $this->preference) {
             throw new \InvalidArgumentException('No preference has been set on MX object.');
@@ -81,7 +81,7 @@ class MX implements RdataInterface
             throw new \InvalidArgumentException('No exchange has been set on MX object.');
         }
 
-        return pack('n', $this->preference).Message::encodeName($this->exchange);
+        return pack('n', $this->preference).Message::encodeName($this->exchange, $origin, $canonicalize);
     }
 
     public function fromText(string $text): void

--- a/lib/Rdata/NAPTR.php
+++ b/lib/Rdata/NAPTR.php
@@ -205,7 +205,7 @@ class NAPTR implements RdataInterface
         );
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         $encoded = pack('nn', $this->order, $this->preference);
         $encoded .= sprintf('"%s""%s""%s"', $this->flags ?? '', $this->services ?? '', $this->regexp);

--- a/lib/Rdata/NAPTR.php
+++ b/lib/Rdata/NAPTR.php
@@ -205,11 +205,11 @@ class NAPTR implements RdataInterface
         );
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         $encoded = pack('nn', $this->order, $this->preference);
         $encoded .= sprintf('"%s""%s""%s"', $this->flags ?? '', $this->services ?? '', $this->regexp);
-        $encoded .= Message::encodeName($this->replacement);
+        $encoded .= Message::encodeName($this->replacement, $origin, $canonicalize);
 
         return $encoded;
     }

--- a/lib/Rdata/NSEC.php
+++ b/lib/Rdata/NSEC.php
@@ -78,7 +78,7 @@ class NSEC implements RdataInterface
     /**
      * @throws UnsupportedTypeException
      */
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return Message::encodeName($this->nextDomainName, $origin, $canonicalize).self::renderBitmap($this->types);
     }

--- a/lib/Rdata/NSEC.php
+++ b/lib/Rdata/NSEC.php
@@ -78,9 +78,9 @@ class NSEC implements RdataInterface
     /**
      * @throws UnsupportedTypeException
      */
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
-        return Message::encodeName($this->nextDomainName).self::renderBitmap($this->types);
+        return Message::encodeName($this->nextDomainName, $origin, $canonicalize).self::renderBitmap($this->types);
     }
 
     public function fromText(string $text): void

--- a/lib/Rdata/NSEC3.php
+++ b/lib/Rdata/NSEC3.php
@@ -197,7 +197,7 @@ class NSEC3 implements RdataInterface
     /**
      * @throws UnsupportedTypeException
      */
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         $wire = pack('CCnC',
             $this->hashAlgorithm,

--- a/lib/Rdata/NSEC3.php
+++ b/lib/Rdata/NSEC3.php
@@ -197,7 +197,7 @@ class NSEC3 implements RdataInterface
     /**
      * @throws UnsupportedTypeException
      */
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         $wire = pack('CCnC',
             $this->hashAlgorithm,

--- a/lib/Rdata/NSEC3PARAM.php
+++ b/lib/Rdata/NSEC3PARAM.php
@@ -115,7 +115,7 @@ class NSEC3PARAM implements RdataInterface
         return sprintf('%d %d %d %s', $this->hashAlgorithm, $this->flags, $this->iterations, bin2hex($this->salt));
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         return pack('CCnC', $this->hashAlgorithm, $this->flags, $this->iterations, strlen($this->salt)).$this->salt;
     }

--- a/lib/Rdata/NSEC3PARAM.php
+++ b/lib/Rdata/NSEC3PARAM.php
@@ -115,7 +115,7 @@ class NSEC3PARAM implements RdataInterface
         return sprintf('%d %d %d %s', $this->hashAlgorithm, $this->flags, $this->iterations, bin2hex($this->salt));
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return pack('CCnC', $this->hashAlgorithm, $this->flags, $this->iterations, strlen($this->salt)).$this->salt;
     }

--- a/lib/Rdata/PolymorphicRdata.php
+++ b/lib/Rdata/PolymorphicRdata.php
@@ -91,7 +91,7 @@ class PolymorphicRdata implements RdataInterface
         return $this->getData() ?? '';
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return $this->data ?? '';
     }

--- a/lib/Rdata/PolymorphicRdata.php
+++ b/lib/Rdata/PolymorphicRdata.php
@@ -18,6 +18,8 @@ namespace Badcow\DNS\Rdata;
  */
 class PolymorphicRdata implements RdataInterface
 {
+    use RdataToDigestableTrait;
+
     /**
      * The RData type.
      *
@@ -89,7 +91,7 @@ class PolymorphicRdata implements RdataInterface
         return $this->getData() ?? '';
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         return $this->data ?? '';
     }

--- a/lib/Rdata/RP.php
+++ b/lib/Rdata/RP.php
@@ -61,9 +61,9 @@ class RP implements RdataInterface
         return sprintf('%s %s', $this->mailboxDomainName, $this->txtDomainName);
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
-        return Message::encodeName($this->mailboxDomainName).Message::encodeName($this->txtDomainName);
+        return Message::encodeName($this->mailboxDomainName, $origin, $canonicalize).Message::encodeName($this->txtDomainName, $origin, $canonicalize);
     }
 
     public function fromText(string $text): void

--- a/lib/Rdata/RP.php
+++ b/lib/Rdata/RP.php
@@ -61,7 +61,7 @@ class RP implements RdataInterface
         return sprintf('%s %s', $this->mailboxDomainName, $this->txtDomainName);
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return Message::encodeName($this->mailboxDomainName, $origin, $canonicalize).Message::encodeName($this->txtDomainName, $origin, $canonicalize);
     }

--- a/lib/Rdata/RRSIG.php
+++ b/lib/Rdata/RRSIG.php
@@ -218,7 +218,7 @@ class RRSIG implements RdataInterface
     /**
      * @throws UnsupportedTypeException
      */
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         $wire = pack('nCCNNNn',
             Types::getTypeCode($this->typeCovered),
@@ -230,7 +230,7 @@ class RRSIG implements RdataInterface
             $this->keyTag
         );
 
-        $wire .= Message::encodeName($this->signersName);
+        $wire .= Message::encodeName($this->signersName, $origin, $canonicalize);
         $wire .= $this->signature;
 
         return $wire;

--- a/lib/Rdata/RRSIG.php
+++ b/lib/Rdata/RRSIG.php
@@ -218,7 +218,7 @@ class RRSIG implements RdataInterface
     /**
      * @throws UnsupportedTypeException
      */
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         $wire = pack('nCCNNNn',
             Types::getTypeCode($this->typeCovered),

--- a/lib/Rdata/RdataInterface.php
+++ b/lib/Rdata/RdataInterface.php
@@ -44,9 +44,9 @@ interface RdataInterface
      * @param bool $canonicalize  Represent all domain names in Rdata in canonicalized format,
      *                            that is all characters lowercase, fully qualified and no compression.
      *
-     * @return packed binary form of Rdata
+     * @return string binary form of Rdata
      */
-    public function toWire(string $origin = null, bool $canonicalize = false);
+    public function toWire(string $origin = null, bool $canonicalize = false): string;
 
     /**
      * Return Rdata wire format which is also suitable for hashing.

--- a/lib/Rdata/RdataInterface.php
+++ b/lib/Rdata/RdataInterface.php
@@ -39,9 +39,20 @@ interface RdataInterface
     /**
      * Return a DNS Server response formatted representation of the Rdata.
      *
-     * @return string packed binary form of Rdata
+     * @param  string  $origin    If non-null and some domain name in Rdata is in relative form,
+     *                            then $origin must be appended to make it FQDN
+     * @param bool $canonicalize  Represent all domain names in Rdata in canonicalized format,
+     *                            that is all characters lowercase, fully qualified and no compression.
+     *
+     * @return packed binary form of Rdata
      */
-    public function toWire(): string;
+    public function toWire(string $origin = null, bool $canonicalize = false);
+
+    /**
+     * Return Rdata wire format which is also suitable for hashing.
+     * @see RdataInterface::toWire()
+     */
+    public function toDigestable(string $origin): string;
 
     /**
      * Populate Rdata object from its textual representation.

--- a/lib/Rdata/RdataInterface.php
+++ b/lib/Rdata/RdataInterface.php
@@ -40,7 +40,7 @@ interface RdataInterface
      * Return a DNS Server response formatted representation of the Rdata.
      *
      * @param  string  $origin    If non-null and some domain name in Rdata is in relative form,
-     *                            then $origin must be appended to make it FQDN
+     *                            then $origin will be appended to make it FQDN
      * @param bool $canonicalize  Represent all domain names in Rdata in canonicalized format,
      *                            that is all characters lowercase, fully qualified and no compression.
      *

--- a/lib/Rdata/RdataToDigestableTrait.php
+++ b/lib/Rdata/RdataToDigestableTrait.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of Badcow DNS Library.
+ *
+ * (c) Samuel Williams <sam@badcow.co>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Badcow\DNS\Rdata;
+
+trait RdataToDigestableTrait
+{
+    /**
+     * Return Rdata wire format which is also suitable for hashing.
+     * @see RdataInterface::toWire()
+     */
+    public function toDigestable(string $origin): string
+    {
+        return $this->toWire($origin, true);
+    }
+}

--- a/lib/Rdata/RdataTrait.php
+++ b/lib/Rdata/RdataTrait.php
@@ -15,6 +15,8 @@ namespace Badcow\DNS\Rdata;
 
 trait RdataTrait
 {
+    use RdataToDigestableTrait;
+
     /**
      * Get the string representation of the Rdata type.
      *

--- a/lib/Rdata/SOA.php
+++ b/lib/Rdata/SOA.php
@@ -200,7 +200,7 @@ class SOA implements RdataInterface
         );
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         if (!isset($this->mname) ||
             !isset($this->rname) ||

--- a/lib/Rdata/SOA.php
+++ b/lib/Rdata/SOA.php
@@ -200,7 +200,7 @@ class SOA implements RdataInterface
         );
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         if (!isset($this->mname) ||
             !isset($this->rname) ||
@@ -213,8 +213,8 @@ class SOA implements RdataInterface
         }
 
         return
-            Message::encodeName($this->mname).
-            Message::encodeName($this->rname).
+            Message::encodeName($this->mname, $origin, $canonicalize).
+            Message::encodeName($this->rname, $origin, $canonicalize).
             pack(
                 'NNNNN',
                 $this->serial,

--- a/lib/Rdata/SRV.php
+++ b/lib/Rdata/SRV.php
@@ -156,9 +156,9 @@ class SRV implements RdataInterface
         );
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
-        return pack('nnn', $this->priority, $this->weight, $this->port).Message::encodeName($this->target);
+        return pack('nnn', $this->priority, $this->weight, $this->port).Message::encodeName($this->target, $origin, $canonicalize);
     }
 
     public function fromText(string $text): void

--- a/lib/Rdata/SRV.php
+++ b/lib/Rdata/SRV.php
@@ -156,7 +156,7 @@ class SRV implements RdataInterface
         );
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return pack('nnn', $this->priority, $this->weight, $this->port).Message::encodeName($this->target, $origin, $canonicalize);
     }

--- a/lib/Rdata/SSHFP.php
+++ b/lib/Rdata/SSHFP.php
@@ -98,7 +98,7 @@ class SSHFP implements RdataInterface
         return sprintf('%d %d %s', $this->algorithm, $this->fingerprintType, bin2hex($this->fingerprint));
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return pack('CC', $this->algorithm, $this->fingerprintType).$this->fingerprint;
     }

--- a/lib/Rdata/SSHFP.php
+++ b/lib/Rdata/SSHFP.php
@@ -98,7 +98,7 @@ class SSHFP implements RdataInterface
         return sprintf('%d %d %s', $this->algorithm, $this->fingerprintType, bin2hex($this->fingerprint));
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         return pack('CC', $this->algorithm, $this->fingerprintType).$this->fingerprint;
     }

--- a/lib/Rdata/TKEY.php
+++ b/lib/Rdata/TKEY.php
@@ -194,7 +194,7 @@ class TKEY implements RdataInterface
         );
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         $wire = Message::encodeName($this->algorithm, $origin, $canonicalize);
         $wire .= pack('NNnnn',

--- a/lib/Rdata/TKEY.php
+++ b/lib/Rdata/TKEY.php
@@ -194,9 +194,9 @@ class TKEY implements RdataInterface
         );
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
-        $wire = Message::encodeName($this->algorithm);
+        $wire = Message::encodeName($this->algorithm, $origin, $canonicalize);
         $wire .= pack('NNnnn',
             $this->inception->format('U'),
             $this->expiration->format('U'),

--- a/lib/Rdata/TLSA.php
+++ b/lib/Rdata/TLSA.php
@@ -119,7 +119,7 @@ class TLSA implements RdataInterface
         return sprintf('%d %d %d %s', $this->certificateUsage, $this->selector, $this->matchingType, bin2hex($this->certificateAssociationData));
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return pack('CCC', $this->certificateUsage, $this->selector, $this->matchingType).$this->certificateAssociationData;
     }

--- a/lib/Rdata/TLSA.php
+++ b/lib/Rdata/TLSA.php
@@ -119,7 +119,7 @@ class TLSA implements RdataInterface
         return sprintf('%d %d %d %s', $this->certificateUsage, $this->selector, $this->matchingType, bin2hex($this->certificateAssociationData));
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         return pack('CCC', $this->certificateUsage, $this->selector, $this->matchingType).$this->certificateAssociationData;
     }

--- a/lib/Rdata/TSIG.php
+++ b/lib/Rdata/TSIG.php
@@ -166,7 +166,7 @@ class TSIG implements RdataInterface
         );
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         $timeSigned = (int) $this->timeSigned->format('U');
         $hex1 = (0xffff00000000 & $timeSigned) >> 32;

--- a/lib/Rdata/TSIG.php
+++ b/lib/Rdata/TSIG.php
@@ -166,14 +166,14 @@ class TSIG implements RdataInterface
         );
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         $timeSigned = (int) $this->timeSigned->format('U');
         $hex1 = (0xffff00000000 & $timeSigned) >> 32;
         $hex2 = (0x0000ffff0000 & $timeSigned) >> 16;
         $hex3 = 0x00000000ffff & $timeSigned;
 
-        $wire = Message::encodeName($this->algorithmName);
+        $wire = Message::encodeName($this->algorithmName, $origin, $canonicalize);
         $wire .= pack('nnnnn', $hex1, $hex2, $hex3, $this->fudge, strlen($this->mac));
         $wire .= $this->mac;
         $wire .= pack('nnn', $this->originalId, $this->error, strlen($this->otherData));

--- a/lib/Rdata/TXT.php
+++ b/lib/Rdata/TXT.php
@@ -58,7 +58,7 @@ class TXT implements RdataInterface
         return implode(' ', $chunks);
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return $this->text ?? '';
     }

--- a/lib/Rdata/TXT.php
+++ b/lib/Rdata/TXT.php
@@ -58,7 +58,7 @@ class TXT implements RdataInterface
         return implode(' ', $chunks);
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         return $this->text ?? '';
     }

--- a/lib/Rdata/URI.php
+++ b/lib/Rdata/URI.php
@@ -118,7 +118,7 @@ class URI implements RdataInterface
         );
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         return pack('nn', $this->priority, $this->weight).$this->target;
     }

--- a/lib/Rdata/URI.php
+++ b/lib/Rdata/URI.php
@@ -118,7 +118,7 @@ class URI implements RdataInterface
         );
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return pack('nn', $this->priority, $this->weight).$this->target;
     }

--- a/lib/Rdata/UnknownType.php
+++ b/lib/Rdata/UnknownType.php
@@ -73,7 +73,7 @@ class UnknownType implements RdataInterface
         return sprintf('\# %d %s', strlen($this->data), bin2hex($this->data));
     }
 
-    public function toWire(string $origin = null, bool $canonicalize = false)
+    public function toWire(string $origin = null, bool $canonicalize = false): string
     {
         return $this->data ?? '';
     }

--- a/lib/Rdata/UnknownType.php
+++ b/lib/Rdata/UnknownType.php
@@ -21,6 +21,8 @@ use Badcow\DNS\Parser\Tokens;
  */
 class UnknownType implements RdataInterface
 {
+    use RdataToDigestableTrait;
+
     /**
      * @var int
      */
@@ -71,7 +73,7 @@ class UnknownType implements RdataInterface
         return sprintf('\# %d %s', strlen($this->data), bin2hex($this->data));
     }
 
-    public function toWire(): string
+    public function toWire(string $origin = null, bool $canonicalize = false)
     {
         return $this->data ?? '';
     }

--- a/lib/ResourceRecord.php
+++ b/lib/ResourceRecord.php
@@ -192,7 +192,9 @@ class ResourceRecord
     }
 
     /**
-     * @param  string  $origin      This value will be forwarded to RDATA wire generator.
+     * @param  string  $origin    If non-null and $this->name is in relative form,
+     *                            then $origin will be appended to make it FQDN.
+     *                            This value will be also forwarded to RDATA wire generator.
      * @param  bool  $canonicalize  Represent owner name ($this->name) in canonicalized format,
      *                              that is all characters lowercase, fully qualified and no compression.
      *                              This value will be also forwarded to RDATA wire generator.
@@ -216,10 +218,6 @@ class ResourceRecord
         if (null === $this->ttl) {
             throw new UnsetValueException('ResourceRecord TTL has not been set.');
         }
-
-/*        if (!Validator::fullyQualifiedDomainName($this->name)) {
-            throw new InvalidArgumentException(sprintf('"%s" is not a fully qualified domain name.', $this->name));
-        }*/
 
         $rdata = $this->rdata->toWire($origin, $canonicalize);
 

--- a/lib/ResourceRecord.php
+++ b/lib/ResourceRecord.php
@@ -217,13 +217,13 @@ class ResourceRecord
             throw new UnsetValueException('ResourceRecord TTL has not been set.');
         }
 
-        if (!Validator::fullyQualifiedDomainName($this->name)) {
+/*        if (!Validator::fullyQualifiedDomainName($this->name)) {
             throw new InvalidArgumentException(sprintf('"%s" is not a fully qualified domain name.', $this->name));
-        }
+        }*/
 
         $rdata = $this->rdata->toWire($origin, $canonicalize);
 
-        $encoded = Message::encodeName($this->name, null, $canonicalize);
+        $encoded = Message::encodeName($this->name, $origin, $canonicalize);
         $encoded .= pack('nnNn',
             $this->rdata->getTypeCode(),
             $this->classId,

--- a/lib/ResourceRecord.php
+++ b/lib/ResourceRecord.php
@@ -218,6 +218,22 @@ class ResourceRecord
             throw new UnsetValueException('ResourceRecord TTL has not been set.');
         }
 
+        /*
+         * The FQDN check here should be reworked.
+         * Currently it doesn't work when:
+         *  - relative name was parsed from Zone file OR
+         *  - @ was parsed as the hostname from Zone file OR
+         *  - wildcard hostname was parsed from Zone file
+         *
+         * Currently we bypass the check if $canonicalize is enabled, thus leaving the
+         * checking up to Message::encodeName()
+         */
+        if (!$canonicalize) {
+            if (!Validator::fullyQualifiedDomainName($this->name)) {
+                throw new InvalidArgumentException(sprintf('"%s" is not a fully qualified domain name.', $this->name));
+            }
+        }
+
         $rdata = $this->rdata->toWire($origin, $canonicalize);
 
         $encoded = Message::encodeName($this->name, $origin, $canonicalize);

--- a/lib/ResourceRecord.php
+++ b/lib/ResourceRecord.php
@@ -17,7 +17,6 @@ use Badcow\DNS\Rdata\A;
 use Badcow\DNS\Rdata\DecodeException;
 use Badcow\DNS\Rdata\Factory;
 use Badcow\DNS\Rdata\RdataInterface;
-use Badcow\DNS\Validator;
 use InvalidArgumentException;
 
 class ResourceRecord


### PR DESCRIPTION
I'm facing the problem where this otherwise great library lacks support for [Resource Record canonical form](https://datatracker.ietf.org/doc/html/rfc4034#section-6.2)

This is quite easily accomplished by adding 2 parameters (```$origin``` and ```$canonicalize```) to following methods:
```php
Badcow\DNS\Message::encodeName(string $name, string $origin = null, bool $canonicalize = false)
Badcow\DNS\ResourceRecord::toWire(string $origin = null, bool $canonicalize = false)
Badcow\DNS\Rdata\RdataInterface::toWire(string $origin = null, bool $canonicalize = false)
```

Method ```Badcow\DNS\Message::encodeName``` is now responsible for:
1. converting ```$name``` to full qualified domain names **if ```$origin``` is specified**
2. converting ```$name``` to canonicalized format (make it lowercase and verify it's FQDN) **if ```$canonicalize``` is true**

Methods ```Badcow\DNS\ResourceRecord::toWire``` and ```Badcow\DNS\Rdata\RdataInterface::toWire``` are now responsible for forwarding the input parameters to ```Badcow\DNS\Message::encodeName``` calls.

For convenience, next to the ```toWire(...)``` methods there is also wrapper ```toDigestable(string $origin)```, which calls ```toWire(...)``` with ```$canonicalize=true```.

These would be non-breaking changes, so backward compatibility is retained.