### PR TITLE
Fix to prevent double stripping of backslashes.

### DIFF
--- a/lib/Rdata/TXT.php
+++ b/lib/Rdata/TXT.php
@@ -33,7 +33,7 @@ class TXT implements RdataInterface
      */
     private $text;
 
-    public function setText(?string $text): void
+    public function setText(?string $text, bool $stripped = false): void
     {
         if (null === $text) {
             $this->text = null;
@@ -41,7 +41,7 @@ class TXT implements RdataInterface
             return;
         }
 
-        $this->text = stripslashes($text);
+        $this->text = $stripped ? $text : stripslashes($text);
     }
 
     public function getText(): string
@@ -92,7 +92,7 @@ class TXT implements RdataInterface
             break;
         }
 
-        $this->setText((string) $txt);
+        $this->setText((string) $txt, true);
     }
 
     /**

--- a/tests/Rdata/TxtTest.php
+++ b/tests/Rdata/TxtTest.php
@@ -62,6 +62,7 @@ class TxtTest extends TestCase
             ['foo bar', 'foo'],
             ["\t\t\tfoobar", 'foobar'],
             ['3600', '3600'],
+            ['double escape sequence \\010', 'double escape sequence \010'],
         ];
     }
 


### PR DESCRIPTION
@samuelwilliams parsing a bind file like below currently triggers a unicode conversion to occur, stripslashes appears to be the problem but when reading fromText the handleTxt method already strips the necessary back slashes, re-stripping them in setText is then a problem

Even if it's rather unlikely \\010 will ever be needed in a TXT record the parser shouldn't convert things to unicode if the double escape sequence followed by numbers does occur.

```
$ORIGIN example.com.
@ 100 IN TXT "text\\010some more text"
```