### PR TITLE
removed strict hostname validator for Question::setName

### DIFF
--- a/lib/Question.php
+++ b/lib/Question.php
@@ -48,7 +48,7 @@ class Question
      */
     public function setName($name): void
     {
-        if (!Validator::fullyQualifiedDomainName($name)) {
+        if (!Validator::fullyQualifiedDomainName($name, false)) {
             throw new InvalidArgumentException(sprintf('"%s" is not a fully qualified domain name.', $name));
         }
 

--- a/lib/Validator.php
+++ b/lib/Validator.php
@@ -43,18 +43,31 @@ class Validator
     }
 
     /**
+     * Validate the string as a valid domain name, without the strict character checking of hostName().
+     */
+    public static function domainName(string $name): bool
+    {
+        return (bool) filter_var($name, FILTER_VALIDATE_DOMAIN);
+    }
+
+    /**
      * Validate the string is a Fully Qualified Domain Name.
      */
-    public static function fullyQualifiedDomainName(string $name): bool
+    public static function fullyQualifiedDomainName(string $name, bool $strictHostValidation = true): bool
     {
         if ('.' === $name) {
             return true;
         }
+
         if ('.' !== substr($name, -1, 1)) {
             return false;
         }
 
-        return self::hostName($name);
+        if ($strictHostValidation) {
+            return self::hostName($name);
+        }
+
+        return self::domainName($name);
     }
 
     /**

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -300,6 +300,8 @@ class ValidatorTest extends TestCase
             ['alt2.aspmx.l.google.com.', true],
             ['www.eXAMple.cOm.', true],
             ['3xample.com.', true],
+            ['_sip._tcp.example.com.', true, false],
+            ['_sip._tcp.example.com.', false, true],
             ['_example.com.', false],
             ['-example.com.', false],
             ['example.com', false],
@@ -310,9 +312,9 @@ class ValidatorTest extends TestCase
     /**
      * @dataProvider getTestFqdnDataProvider
      */
-    public function testFqdn(string $domain, bool $isValid): void
+    public function testFqdn(string $domain, bool $isValid, bool $strictHostValidation = true): void
     {
-        $this->assertEquals($isValid, Validator::fullyQualifiedDomainName($domain));
+        $this->assertEquals($isValid, Validator::fullyQualifiedDomainName($domain, $strictHostValidation));
     }
 
     public function testHostName(): void


### PR DESCRIPTION
Instead just validate the domain name is valid. This allows us to use domains like `_sip._tcp.example.com` in Questions which would otherwise fail because of the Question::setName()'s reliance on the validator.

This is useful when constructing a question to later pass to an actual DNS query via the `toWire()` method on the message.

Reference to a similar case with resource records: https://github.com/Badcow/DNS/commit/af12eb96a5f507b6d739589c3391ee3b4ca996ec