### PR TITLE
Added support for empty salt ( aka dash )

### DIFF
--- a/lib/Rdata/NSEC3PARAM.php
+++ b/lib/Rdata/NSEC3PARAM.php
@@ -104,6 +104,10 @@ class NSEC3PARAM implements RdataInterface
      */
     public function setSalt(string $salt): void
     {
+        if ($salt == "-") {
+            $this->salt = "-";
+            return;
+        }
         if (false === $bin = @hex2bin($salt)) {
             throw new \InvalidArgumentException('Salt must be a hexadecimal string.');
         }

--- a/lib/Rdata/NSEC3PARAM.php
+++ b/lib/Rdata/NSEC3PARAM.php
@@ -96,6 +96,7 @@ class NSEC3PARAM implements RdataInterface
      */
     public function getSalt(): string
     {
+        if ($this->salt == "-") return $this->salt;
         return bin2hex($this->salt);
     }
 


### PR DESCRIPTION
When using \Badcow\DNS\Parser\Parser::parse, and the zone file contains and empty salt in the NSEC3PARAM, it throws an error:
```
Could not extract Rdata from resource record " 0 NSEC3PARAM 1 0 0 -"."
```

This is because the setSalt function in Rdata/NSEC3PARAM.php is as follows:
```php
    public function setSalt(string $salt): void
    {
        if (false === $bin = @hex2bin($salt)) {
            throw new \InvalidArgumentException('Salt must be a hexadecimal string.');
        }
        $this->salt = $bin;
    }
```

This is a problem, because the salt can be empty ( dash ) but this is not support in this function.
Adding a simple check to see if its a dash, and just return, resolves this issue.

I dont know if you guys want it written differently, let me know.


This is also a issue in getSalt and fromWire