### PR TITLE
fixed parsing of empty names with multiple $ORIGINS

### DIFF
--- a/lib/Parser/Parser.php
+++ b/lib/Parser/Parser.php
@@ -253,6 +253,10 @@ class Parser
      */
     private function appendOrigin(string $subdomain): string
     {
+        if (empty($subdomain)) {
+            return $subdomain;
+        }
+
         if ($this->origin === $this->zone->getName()) {
             return $subdomain;
         }

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -532,6 +532,20 @@ DNS;
     }
 
     /**
+     * Parser handles empty names with multiple $ORIGINS.
+     *
+     * @throws ParseException|\Exception
+     */
+    public function testParserHandlesEmptyNamesWithMultipleOrigins(): void
+    {
+        $file = NormaliserTest::readFile(__DIR__.'/Resources/testEmptyNamesWithMultipleOrigins.txt');
+        $expectation = NormaliserTest::readFile(__DIR__.'/Resources/testEmptyNamesWithMultipleOrigins_expectation.txt');
+        $zone = Parser::parse('mydomain.biz.', $file);
+
+        $this->assertEquals($expectation, ZoneBuilder::build($zone));
+    }
+
+    /**
      * Parser handles $ORIGIN . correctly.
      *
      * @throws ParseException|\Exception

--- a/tests/Parser/Resources/testEmptyNamesWithMultipleOrigins.txt
+++ b/tests/Parser/Resources/testEmptyNamesWithMultipleOrigins.txt
@@ -1,0 +1,10 @@
+$ORIGIN mydomain.biz.
+$TTL 3600
+
+test A 192.168.1.42
+     A 192.168.1.43
+
+$ORIGIN _subdomain.mydomain.biz.
+
+test A 192.168.2.42
+     A 192.168.2.43

--- a/tests/Parser/Resources/testEmptyNamesWithMultipleOrigins_expectation.txt
+++ b/tests/Parser/Resources/testEmptyNamesWithMultipleOrigins_expectation.txt
@@ -1,0 +1,6 @@
+$ORIGIN mydomain.biz.
+$TTL 3600
+test 3600 IN A 192.168.1.42
+test 3600 IN A 192.168.1.43
+test._subdomain.mydomain.biz. 3600 IN A 192.168.2.42
+test._subdomain.mydomain.biz. 3600 IN A 192.168.2.43


### PR DESCRIPTION
When an $ORIGIN is defined that is different from the zone name, then records with "empty names" (which refer to the previous record) are not correctly parsed.

Example input for zone "mydomain.biz.":
```
$ORIGIN _subdomain.mydomain.biz.

test A 192.168.2.42
     A 192.168.2.43
```

The second entry is parsed as "._subdomain.mydomain.biz." instead of "**test**._subdomain.mydomain.biz.".

I think the best fix is to check for empty name in `appendOrigin()`, so it is correctly handled by `populateNullValues()` later (as it is already handled if we are in main zone context).

This PR implements the fix with the corresponding test.