### PR TITLE
Fix stack overflow on self-referential compression pointer

### DIFF
--- a/lib/Message.php
+++ b/lib/Message.php
@@ -138,8 +138,12 @@ class Message
         return $res;
     }
 
-    public static function decodeName(string $string, int &$offset = 0): string
+    public static function decodeName(string $string, int &$offset = 0, int $depth = 0): string
     {
+        if ($depth > 127) {
+            throw new \UnexpectedValueException('DNS name has too many compression pointers');
+        }
+
         $len = ord($string[$offset]);
         ++$offset;
 
@@ -163,7 +167,7 @@ class Message
             $offset += $len;
             $len = ord($string[$offset]);
             if ($len & 0b11000000) {
-                $name .= self::decodeName($string, $offset);
+                $name .= self::decodeName($string, $offset, $depth + 1);
                 break;
             }
 

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -27,6 +27,7 @@ use Badcow\DNS\Rdata\UnsupportedTypeException;
 use Badcow\DNS\ResourceRecord;
 use Badcow\DNS\UnsetValueException;
 use PHPUnit\Framework\TestCase;
+use UnexpectedValueException;
 
 class MessageTest extends TestCase
 {
@@ -264,6 +265,12 @@ class MessageTest extends TestCase
         $this->assertCount(1, $additionals);
         $this->assertInstanceOf(OPT::class, $additionals[0]->getRdata());
         $this->assertEquals($expectation, $msg->toWire());
+    }
+
+    public function testWire10(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        Message::fromWire($this->getWireTestData(10));
     }
 
     /**

--- a/tests/Resources/wire/wire_test.data10
+++ b/tests/Resources/wire/wire_test.data10
@@ -1,0 +1,13 @@
+# HEADER SECTION
+30 99  # ID
+01 00  # FLAGS
+00 01  # QDCOUNT=1
+00 00  # ANCOUNT=0
+00 00  # NSCOUNT=0
+00 00  # ARCOUNT=0
+
+# QUESTION SECTION
+01 61  # QNAME label: len=1, "a"
+c0 0c  # compression pointer -> offset 0x0C (12) = start of QNAME
+00 01  # QTYPE=A
+00 01  # QCLASS=IN


### PR DESCRIPTION
`Message::decodeName` follows compression pointers by recursing without checking the chain terminates. A name pointing back into itself recurses forever will exhausting memory and can used to do a remote DoS attack.
I fixed it by adding a `$depth` arg and increment it per recurse, throwing an exception past 127.