### PR TITLE
Fix encoding TXT records as length-prefixed character-strings

### DIFF
--- a/lib/Rdata/TXT.php
+++ b/lib/Rdata/TXT.php
@@ -60,14 +60,26 @@ class TXT implements RdataInterface
 
     public function toWire(): string
     {
-        return $this->text ?? '';
+        $wire = '';
+        foreach (str_split($this->text ?? '', 255) as $chunk) {
+            $wire .= chr(strlen($chunk)).$chunk;
+        }
+
+        return '' === $wire ? "\x00" : $wire;
     }
 
     public function fromWire(string $rdata, int &$offset = 0, ?int $rdLength = null): void
     {
         $rdLength = $rdLength ?? strlen($rdata);
-        $this->setText(substr($rdata, $offset, $rdLength));
-        $offset += $rdLength;
+        $end = $offset + $rdLength;
+        $text = '';
+        while ($offset < $end) {
+            $length = ord($rdata[$offset]);
+            ++$offset;
+            $text .= substr($rdata, $offset, $length);
+            $offset += $length;
+        }
+        $this->setText($text, true);
     }
 
     public function fromText(string $text): void

--- a/tests/Rdata/SpfTest.php
+++ b/tests/Rdata/SpfTest.php
@@ -42,15 +42,16 @@ class SpfTest extends TestCase
 
     public function testWire(): void
     {
-        $wireFormat = chr(49).'v=spf1 ip4:192.0.2.0/24 ip4:198.51.100.123 a -all';
-        $offset = 1;
-        $rdLength = 49;
+        $text = 'v=spf1 ip4:192.0.2.0/24 ip4:198.51.100.123 a -all';
+        $wireFormat = chr(strlen($text)).$text;
 
         $spf = new SPF();
-        $spf->setText('v=spf1 ip4:192.0.2.0/24 ip4:198.51.100.123 a -all');
+        $spf->setText($text);
+        $this->assertEquals($wireFormat, $spf->toWire());
 
+        $offset = 0;
         $fromWire = new SPF();
-        $fromWire->fromWire($wireFormat, $offset, $rdLength);
+        $fromWire->fromWire($wireFormat, $offset, strlen($wireFormat));
         $this->assertEquals($spf, $fromWire);
     }
 

--- a/tests/Rdata/TxtTest.php
+++ b/tests/Rdata/TxtTest.php
@@ -76,15 +76,44 @@ class TxtTest extends TestCase
         $this->assertEquals($expectation, $txt->getText());
     }
 
-    public function testWire(): void
+    public function testWire1(): void
     {
-        $expectation = 'This is some text. It\'s a nice piece of text.';
+        $text = 'This is some text. It\'s a nice piece of text.';
         $txt = new TXT();
-        $txt->setText($expectation);
+        $txt->setText($text);
 
-        $this->assertEquals($expectation, $txt->toWire());
+        $this->assertEquals(chr(strlen($text)).$text, $txt->toWire());
+
         $fromWire = new TXT();
-        $fromWire->fromWire($expectation);
+        $fromWire->fromWire($txt->toWire());
         $this->assertEquals($txt, $fromWire);
+    }
+
+    public function testWire2(): void
+    {
+        $text = str_repeat('a', 255).str_repeat('b', 100);
+        $txt = new TXT();
+        $txt->setText($text);
+
+        $this->assertEquals(
+            chr(255).str_repeat('a', 255).chr(100).str_repeat('b', 100),
+            $txt->toWire()
+        );
+
+        $fromWire = new TXT();
+        $fromWire->fromWire($txt->toWire());
+        $this->assertEquals($text, $fromWire->getText());
+    }
+
+    public function testWire3(): void
+    {
+        $txt = new TXT();
+        $txt->setText('');
+
+        $this->assertEquals("\x00", $txt->toWire());
+
+        $fromWire = new TXT();
+        $fromWire->fromWire($txt->toWire());
+        $this->assertEquals('', $fromWire->getText());
     }
 }


### PR DESCRIPTION
`TXT::toWire()/fromWire()` previously emitted and parsed raw text without a length byte, which `dig` rejects as malformed.

They now encode and decode length-prefixed data, splitting it at 255 octets.
Naturally, SPF inherits both the problem and the fix.