### PR TITLE
Fix encoding ResourceRecord with underscore on their name

### DIFF
--- a/lib/ResourceRecord.php
+++ b/lib/ResourceRecord.php
@@ -209,7 +209,7 @@ class ResourceRecord
             throw new UnsetValueException('ResourceRecord TTL has not been set.');
         }
 
-        if (!Validator::fullyQualifiedDomainName($this->name)) {
+        if (!Validator::fullyQualifiedDomainName($this->name, false)) {
             throw new InvalidArgumentException(sprintf('"%s" is not a fully qualified domain name.', $this->name));
         }
 

--- a/tests/ResourceRecordTest.php
+++ b/tests/ResourceRecordTest.php
@@ -121,6 +121,19 @@ class ResourceRecordTest extends TestCase
         $this->assertEquals($expectation, $rr->toWire());
     }
 
+    public function testToWireNameWithUnderscore(): void
+    {
+        $rr = new ResourceRecord();
+        $rr->setName('_sip._tcp.example.com.');
+        $rr->setClass(Classes::INTERNET);
+        $rr->setRdata(Factory::SRV(0, 5, 5060, 'sip.example.com.'));
+        $rr->setTtl(3600);
+
+        $decoded = ResourceRecord::fromWire($rr->toWire());
+
+        $this->assertEquals('_sip._tcp.example.com.', $decoded->getName());
+    }
+
     public function dataProviderForTestToWireThrowsExceptionsIfValuesAreNotSet(): array
     {
         $rr_noName = new ResourceRecord();


### PR DESCRIPTION
`ResourceRecord::toWire()` rejected valid owner names containing underscores (like `_sip._tcp` or `_dmarc`) because it used strict hostname validation.
Switched to non-strict FQDN validation (matching `Question::setName()`) so SRV/TXT records encode instead of throwing.